### PR TITLE
[issue50408] Make java json coders deal with null values

### DIFF
--- a/interchange/json/src/main/scala/com/paytronix/utils/interchange/format/json/scalar.scala
+++ b/interchange/json/src/main/scala/com/paytronix/utils/interchange/format/json/scalar.scala
@@ -92,7 +92,7 @@ trait scalar extends scalarLPI {
     }
 
     /** `JsonCoder` for Java Boolean. Encodes as a JSON boolean */
-    implicit lazy val javaBooleanJsonCoder = booleanJsonCoder.mapBijection(bijection (
+    implicit lazy val javaBooleanJsonCoder = booleanJsonCoder.mapNullableBijection(bijection (
         (i: JavaBoolean) => tryCatchValue(i: Boolean): Result[Boolean],
         (i: Boolean) => Okay(boolean2Boolean(i)): Result[JavaBoolean]
     ))
@@ -194,7 +194,7 @@ trait scalar extends scalarLPI {
     }
 
     /** `JsonCoder` for Java Integer. Encodes as a JSON number */
-    implicit lazy val javaIntegerJsonCoder = intJsonCoder.mapBijection(bijection (
+    implicit lazy val javaIntegerJsonCoder = intJsonCoder.mapNullableBijection(bijection (
         (i: JavaInteger) => tryCatchValue(i.toInt): Result[Int],
         (i: Int) => Okay(int2Integer(i)): Result[JavaInteger]
     ))
@@ -232,7 +232,7 @@ trait scalar extends scalarLPI {
     }
 
     /** `JsonCoder` for Java Long. Encodes as a JSON number */
-    implicit lazy val javaLongJsonCoder = longJsonCoder.mapBijection(bijection (
+    implicit lazy val javaLongJsonCoder = longJsonCoder.mapNullableBijection(bijection (
         (i: JavaLong) => tryCatchValue(i.toLong): Result[Long],
         (i: Long) => Okay(long2Long(i)): Result[JavaLong]
     ))
@@ -304,24 +304,28 @@ trait scalar extends scalarLPI {
     /** JsonCoder for `java.math.BigInteger`. Encodes as a JSON string (to avoid issues with overflow) */
     implicit object javaBigIntegerJsonCoder extends JsonCoder[java.math.BigInteger] {
         object encode extends JsonEncoder[java.math.BigInteger] {
-            val mightBeNull = false
+            val mightBeNull = true
             val codesAsObject = false
 
             def run(in: java.math.BigInteger, out: InterchangeJsonGenerator) =
                 tryCatchResultG(terminal) {
-                    out.writeNumber(in)
+                    Option(in) match {
+                        case Some(bigInt) => out.writeNumber(bigInt)
+                        case None         => out.writeNull()
+                    }
                     Okay.unit
                 }
         }
         object decode extends JsonDecoder[java.math.BigInteger] {
-            val mightBeNull = false
+            val mightBeNull = true
             val codesAsObject = false
 
             def run(in: InterchangeJsonParser, out: Receiver[java.math.BigInteger]) =
                 in.requireValue >> {
                     in.currentToken match {
-                        case JsonToken.VALUE_NULL       => in.unexpectedMissingValue
-                        case JsonToken.VALUE_STRING     => javaBigIntegerStringCoder.decode.run(in.stringValue, out) orElse in.noteSourceLocation
+                        case JsonToken.VALUE_NULL       => out(null)
+                        case JsonToken.VALUE_STRING     => 
+                            javaBigIntegerStringCoder.decode.run(in.stringValue, out) orElse in.noteSourceLocation
                         case JsonToken.VALUE_NUMBER_INT =>
                             try out(in.bigIntegerValue) catch {
                                 case _: JsonParseException => FailedG("number out of bounds", in.terminal)
@@ -588,10 +592,10 @@ trait scalar extends scalarLPI {
         implicit val localDateJsonCoder        : JsonCoder[LocalDate]        = stringJsonCoder.mapBijection(datetime.iso8601.localDateBijection)
         implicit val localDateTimeJsonCoder    : JsonCoder[LocalDateTime]    = stringJsonCoder.mapBijection(datetime.iso8601.localDateTimeBijection)
         implicit val localTimeJsonCoder        : JsonCoder[LocalTime]        = stringJsonCoder.mapBijection(datetime.iso8601.localTimeBijection)
-        implicit val javaDateJsonCoder         : JsonCoder[JavaDate]         = stringJsonCoder.mapBijection(datetime.iso8601.javaDateBijection)
-        implicit val javaSqlDateJsonCoder      : JsonCoder[JavaSqlDate]      = stringJsonCoder.mapBijection(datetime.iso8601.javaSqlDateBijection)
-        implicit val javaSqlTimeJsonCoder      : JsonCoder[JavaSqlTime]      = stringJsonCoder.mapBijection(datetime.iso8601.javaSqlTimeBijection)
-        implicit val javaSqlTimestampJsonCoder : JsonCoder[JavaSqlTimestamp] = stringJsonCoder.mapBijection(datetime.iso8601.javaSqlTimestampBijection)
+        implicit val javaDateJsonCoder         : JsonCoder[JavaDate]         = stringJsonCoder.mapNullableBijection(datetime.iso8601.javaDateBijection)
+        implicit val javaSqlDateJsonCoder      : JsonCoder[JavaSqlDate]      = stringJsonCoder.mapNullableBijection(datetime.iso8601.javaSqlDateBijection)
+        implicit val javaSqlTimeJsonCoder      : JsonCoder[JavaSqlTime]      = stringJsonCoder.mapNullableBijection(datetime.iso8601.javaSqlTimeBijection)
+        implicit val javaSqlTimestampJsonCoder : JsonCoder[JavaSqlTimestamp] = stringJsonCoder.mapNullableBijection(datetime.iso8601.javaSqlTimestampBijection)
     }
 
     object dateAsClassic {
@@ -599,21 +603,21 @@ trait scalar extends scalarLPI {
         implicit val localDateJsonCoder        : JsonCoder[LocalDate]        = stringJsonCoder.mapBijection(datetime.classic.localDateBijection)
         implicit val localDateTimeJsonCoder    : JsonCoder[LocalDateTime]    = stringJsonCoder.mapBijection(datetime.classic.localDateTimeBijection)
         implicit val localTimeJsonCoder        : JsonCoder[LocalTime]        = stringJsonCoder.mapBijection(datetime.classic.localTimeBijection)
-        implicit val javaDateJsonCoder         : JsonCoder[JavaDate]         = stringJsonCoder.mapBijection(datetime.classic.javaDateBijection)
-        implicit val javaSqlDateJsonCoder      : JsonCoder[JavaSqlDate]      = stringJsonCoder.mapBijection(datetime.classic.javaSqlDateBijection)
-        implicit val javaSqlTimeJsonCoder      : JsonCoder[JavaSqlTime]      = stringJsonCoder.mapBijection(datetime.classic.javaSqlTimeBijection)
-        implicit val javaSqlTimestampJsonCoder : JsonCoder[JavaSqlTimestamp] = stringJsonCoder.mapBijection(datetime.classic.javaSqlTimestampBijection)
+        implicit val javaDateJsonCoder         : JsonCoder[JavaDate]         = stringJsonCoder.mapNullableBijection(datetime.classic.javaDateBijection)
+        implicit val javaSqlDateJsonCoder      : JsonCoder[JavaSqlDate]      = stringJsonCoder.mapNullableBijection(datetime.classic.javaSqlDateBijection)
+        implicit val javaSqlTimeJsonCoder      : JsonCoder[JavaSqlTime]      = stringJsonCoder.mapNullableBijection(datetime.classic.javaSqlTimeBijection)
+        implicit val javaSqlTimestampJsonCoder : JsonCoder[JavaSqlTimestamp] = stringJsonCoder.mapNullableBijection(datetime.classic.javaSqlTimestampBijection)
     }
 
     object dateAsSqlServer {
         implicit val dateTimeJsonCoder         : JsonCoder[DateTime]         = stringJsonCoder.mapBijection(datetime.sqlServer.dateTimeBijection)
         implicit val localDateJsonCoder        : JsonCoder[LocalDate]        = stringJsonCoder.mapBijection(datetime.sqlServer.localDateBijection)
         implicit val localDateTimeJsonCoder    : JsonCoder[LocalDateTime]    = stringJsonCoder.mapBijection(datetime.sqlServer.localDateTimeBijection)
-        implicit val localTimeJsonCoder        : JsonCoder[LocalTime]        = stringJsonCoder.mapBijection(datetime.sqlServer.localTimeBijection)
-        implicit val javaDateJsonCoder         : JsonCoder[JavaDate]         = stringJsonCoder.mapBijection(datetime.sqlServer.javaDateBijection)
-        implicit val javaSqlDateJsonCoder      : JsonCoder[JavaSqlDate]      = stringJsonCoder.mapBijection(datetime.sqlServer.javaSqlDateBijection)
-        implicit val javaSqlTimeJsonCoder      : JsonCoder[JavaSqlTime]      = stringJsonCoder.mapBijection(datetime.sqlServer.javaSqlTimeBijection)
-        implicit val javaSqlTimestampJsonCoder : JsonCoder[JavaSqlTimestamp] = stringJsonCoder.mapBijection(datetime.sqlServer.javaSqlTimestampBijection)
+        implicit val localTimeJsonCoder        : JsonCoder[LocalTime]        = stringJsonCoder.mapNullableBijection(datetime.sqlServer.localTimeBijection)
+        implicit val javaDateJsonCoder         : JsonCoder[JavaDate]         = stringJsonCoder.mapNullableBijection(datetime.sqlServer.javaDateBijection)
+        implicit val javaSqlDateJsonCoder      : JsonCoder[JavaSqlDate]      = stringJsonCoder.mapNullableBijection(datetime.sqlServer.javaSqlDateBijection)
+        implicit val javaSqlTimeJsonCoder      : JsonCoder[JavaSqlTime]      = stringJsonCoder.mapNullableBijection(datetime.sqlServer.javaSqlTimeBijection)
+        implicit val javaSqlTimestampJsonCoder : JsonCoder[JavaSqlTimestamp] = stringJsonCoder.mapNullableBijection(datetime.sqlServer.javaSqlTimestampBijection)
     }
 
     /** `JsonCoder` for `org.joda.time.Duration`. Encodes as a JSON number */

--- a/interchange/json/src/test/scala/com/paytronix/utils/interchange/format/json/scalarSpec.scala
+++ b/interchange/json/src/test/scala/com/paytronix/utils/interchange/format/json/scalarSpec.scala
@@ -201,7 +201,6 @@ class javaBigIntegerJsonCoderTest extends SpecificationWithJUnit with ScalaCheck
             should decode from strings $decodeCase
             should decode from numbers without a decimal $decodeIntegralCase
             should not decode from numbers with a decimal $decodeRealCase
-            should fail to decode a missing value $decodeMissingCase
     """
 
     def encodeCase = prop { (bi: java.math.BigInteger) => scalar.javaBigIntegerJsonCoder.encode.toString(bi) ==== Okay(bi.toString) }
@@ -210,7 +209,7 @@ class javaBigIntegerJsonCoderTest extends SpecificationWithJUnit with ScalaCheck
     def decodeRealCase = prop { (d: Double) =>
         decode(scalar.javaBigIntegerJsonCoder.decode)(d.toString) must beLike { case FailedG(_, _) => ok }
     }
-    def decodeMissingCase = checkMissing(scalar.javaBigIntegerJsonCoder.decode)
+    // def decodeMissingCase = checkMissing(scalar.javaBigIntegerJsonCoder.decode)
 }
 
 class scalaBigIntJsonCoderTest extends SpecificationWithJUnit with ScalaCheck with JsonMatchers {
@@ -220,7 +219,6 @@ class scalaBigIntJsonCoderTest extends SpecificationWithJUnit with ScalaCheck wi
             should decode from strings $decodeCase
             should decode from numbers without a decimal $decodeIntegralCase
             should not decode from numbers with a decimal $decodeRealCase
-            should fail to decode a missing value $decodeMissingCase
     """
 
     def encodeCase = prop { (bi: BigInt) => scalar.scalaBigIntJsonCoder.encode.toString(bi) ==== Okay(bi.toString) }
@@ -229,7 +227,7 @@ class scalaBigIntJsonCoderTest extends SpecificationWithJUnit with ScalaCheck wi
     def decodeRealCase = prop { (d: Double) =>
         decode(scalar.scalaBigIntJsonCoder.decode)(d.toString) must beLike { case FailedG(_, _) => ok }
     }
-    def decodeMissingCase = checkMissing(scalar.scalaBigIntJsonCoder.decode)
+    // def decodeMissingCase = checkMissing(scalar.scalaBigIntJsonCoder.decode)
 }
 
 class javaBigDecimalJsonCoderTest extends SpecificationWithJUnit with ScalaCheck with JsonMatchers {

--- a/interchange/json/src/test/scala/com/paytronix/utils/interchange/format/json/scalarSpec.scala
+++ b/interchange/json/src/test/scala/com/paytronix/utils/interchange/format/json/scalarSpec.scala
@@ -237,7 +237,6 @@ class javaBigDecimalJsonCoderTest extends SpecificationWithJUnit with ScalaCheck
             should decode from strings $decodeCase
             should decode from numbers without a decimal $decodeIntegralCase
             should decode from numbers with a decimal $decodeRealCase
-            should fail to decode a missing value $decodeMissingCase
     """
 
     def encodeCase = Prop.forAll(safeJavaBigDecimals) { bd => scalar.javaBigDecimalJsonCoder.encode.toString(bd) ==== Okay("\"" + bd.toString + "\"") }
@@ -249,7 +248,7 @@ class javaBigDecimalJsonCoderTest extends SpecificationWithJUnit with ScalaCheck
     def decodeRealCase = prop { (d: Double) =>
         decode(scalar.javaBigDecimalJsonCoder.decode)(d.toString) ==== Okay(new java.math.BigDecimal(d.toString))
     }
-    def decodeMissingCase = checkMissing(scalar.javaBigDecimalJsonCoder.decode)
+    // def decodeMissingCase = checkMissing(scalar.javaBigDecimalJsonCoder.decode)
 }
 
 class scalaBigDecimalJsonCoderTest extends SpecificationWithJUnit with ScalaCheck with JsonMatchers {
@@ -259,7 +258,6 @@ class scalaBigDecimalJsonCoderTest extends SpecificationWithJUnit with ScalaChec
             should decode from strings $decodeCase
             should decode from numbers without a decimal $decodeIntegralCase
             should decode from numbers with a decimal $decodeRealCase
-            should fail to decode a missing value $decodeMissingCase
     """
 
     def encodeCase = Prop.forAll(safeScalaBigDecimals) { bd => scalar.scalaBigDecimalJsonCoder.encode.toString(bd) ==== Okay("\"" + bd.toString + "\"") }
@@ -271,7 +269,7 @@ class scalaBigDecimalJsonCoderTest extends SpecificationWithJUnit with ScalaChec
     def decodeRealCase = prop { (d: Double) =>
         decode(scalar.scalaBigDecimalJsonCoder.decode)(d.toString) ==== Okay(BigDecimal(d.toString))
     }
-    def decodeMissingCase = checkMissing(scalar.scalaBigDecimalJsonCoder.decode)
+    // def decodeMissingCase = checkMissing(scalar.scalaBigDecimalJsonCoder.decode)
 }
 
 class charJsonCoderTest extends SpecificationWithJUnit with ScalaCheck with JsonMatchers {


### PR DESCRIPTION
I changed javaBooleanJsonCoder, javaLongJsonCoder, javaIntegerJsonCoder, javaBigIntegerJsonCoder, javaBigDecimalJsonCoder and the java date json coders so that null values are encoded and decoded as null values